### PR TITLE
feat: remove the ability to create duplicate handler (global or local)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "@unional/logging": "^0.2.5",
     "assertron": "^3.4.1",
     "flux-standard-action": "^2.0.1",
-    "lodash.merge": "^4.6.1",
     "node-fetch": "^1.7.3",
     "satisfier": "^4.1.1",
     "tersify": "^1.2.2"

--- a/src/environment.spec.ts
+++ b/src/environment.spec.ts
@@ -2,7 +2,7 @@ import { AssertOrder } from 'assertron'
 import { test } from 'ava'
 
 import { onEnvironment, environment } from './environment'
-import { MissingEnvironmentHandler } from './errors'
+import { MissingEnvironmentHandler, DuplicateEnvironmentHandler } from './errors'
 
 test('no handler registered throws MissingEnvironmentHandler', async t => {
   await t.throws(environment('no handler'), MissingEnvironmentHandler)
@@ -17,6 +17,11 @@ test('handler will be invoked', async () => {
   order.end()
 })
 
+test('duplicate handler will throws', async t => {
+  onEnvironment('dup handler', () => { return })
+  await t.throws(() => onEnvironment('dup handler', () => { return }), DuplicateEnvironmentHandler)
+})
+
 test('handler can be registered using regex', async () => {
   const order = new AssertOrder(1)
   onEnvironment(/reg using reg/, () => order.once(1))
@@ -24,6 +29,11 @@ test('handler can be registered using regex', async () => {
   await environment('reg using regex')
 
   order.end()
+})
+
+test('duplicate regex handler will throws', async t => {
+  onEnvironment(/dup regex handler/, () => { return })
+  await t.throws(() => onEnvironment(/dup regex handler/, () => { return }), DuplicateEnvironmentHandler)
 })
 
 test('using environment twice will only invoke handler once', async () => {
@@ -46,38 +56,33 @@ test('resulting env.fixture contains information provided by the handler', async
 })
 
 test('receives async environment context from the handler', async t => {
-  onEnvironment('returning context', () => Promise.resolve({ a: 1 }))
+  onEnvironment('returning async context', () => Promise.resolve({ a: 1 }))
 
-  const actual = await environment<{ a: number }>('returning context')
+  const actual = await environment<{ a: number }>('returning async context')
   t.deepEqual(actual.fixture, { a: 1 })
 })
 
-test('with listener, MissingEnvironmentHandler will not be thrown', () => {
+test('with localHandler, MissingEnvironmentHandler will not be thrown', () => {
   return environment('no throw with listener', () => { return })
 })
 
-test('invoke listener after handler', async () => {
-  const order = new AssertOrder(2)
-  onEnvironment('invoke listener', () => order.once(1))
+test('define localHandler while already has a handler throws DupHandler error', async t => {
+  onEnvironment('invoke localHandler', () => t.fail('should not reach'))
 
-  await environment('invoke listener', () => order.once(2))
-
-  order.end()
+  await t.throws(environment('invoke localHandler', () => { return }), DuplicateEnvironmentHandler)
 })
 
-test('receive context from listener', async t => {
-  onEnvironment('returning listener context', () => ({ a: 1 }))
-
-  const actual = await environment('returning listener context', () => ({ b: 2 }))
-  t.deepEqual(actual.fixture, { a: 1, b: 2 })
+test('receive context from localHandler', async t => {
+  const actual = await environment('returning localHandler context', () => ({ b: 2 }))
+  t.deepEqual(actual.fixture, { b: 2 })
 })
 
 
-test('receive async context from listener', async t => {
-  onEnvironment('returning async listener context', () => ({ a: 1 }))
-
-  const actual = await environment<{ a: number } & { b: number }>('returning async listener context', () => Promise.resolve({ b: 2 }))
-  t.deepEqual(actual.fixture, { a: 1, b: 2 })
+test('receive async context from localHandler', async t => {
+  const actual = await environment<{ a: number } & { b: number }>(
+    'returning async localHandler context',
+    () => Promise.resolve({ b: 2 }))
+  t.deepEqual(actual.fixture, { b: 2 })
 })
 
 test('simulate model calls handler with EnvironmentContext', async t => {
@@ -91,15 +96,11 @@ test('simulate model calls handler with EnvironmentContext', async t => {
   o.end()
 })
 
-test('simulate model calls listener with EnvironmentContext', async t => {
-  const o = new AssertOrder(2)
-  onEnvironment('simulate mode', ({ mode }) => {
-    o.once(1)
-    t.is(mode, 'simulate')
-  })
+test('simulate model calls local handler with EnvironmentContext', async t => {
+  const o = new AssertOrder(1)
 
-  await environment.simulate('simulate mode', ({ mode }) => {
-    o.once(2)
+  await environment.simulate('simulate mode with local handler', ({ mode }) => {
+    o.once(1)
     t.is(mode, 'simulate')
   })
   o.end()
@@ -118,17 +119,30 @@ test('simulating environment will force spec to simulate', async t => {
     return cbSpec.satisfy([undefined, { payload: [undefined, 3] }])
   })
 
-  await environment.simulate('simulate calling env', ({ mode }) => {
+  await environment.simulate('simulate calling env')
+})
+
+test('simulating environment will force spec in localHandler to simulate', async t => {
+  function success(_a, _cb) {
+    // callback(null, a + 1)
+    t.fail('should not reach')
+  }
+
+  await environment.simulate('simulate calling env with localHandler', async ({ mode, spec }) => {
     t.is(mode, 'simulate')
+    const cbSpec = await spec('environment/simulate/spec', success)
+    cbSpec.subject(2, (_, a) => t.is(a, 3))
+
+    return cbSpec.satisfy([undefined, { payload: [undefined, 3] }])
   })
 })
 
 test('environment context contains spec', async t => {
   onEnvironment('context has spec', ({ spec }) => t.truthy(spec))
-  await environment('context has spec', ({ spec }) => t.truthy(spec))
+  await environment('local context has spec', ({ spec }) => t.truthy(spec))
 })
 
 test('simulate environment context contains spec', async t => {
   onEnvironment('simulate context has spec', ({ spec }) => t.truthy(spec))
-  await environment.simulate('simulate context has spec', ({ spec }) => t.truthy(spec))
+  await environment.simulate('simulate local context has spec', ({ spec }) => t.truthy(spec))
 })

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,3 +13,11 @@ export class MissingSpecID extends Error {
     Object.setPrototypeOf(this, new.target.prototype)
   }
 }
+
+export class DuplicateEnvironmentHandler extends Error {
+  constructor(public clause: string | RegExp) {
+    super(`Handler for '${clause}' is already defined.`)
+
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}


### PR DESCRIPTION
This reduces confusion.
Just use promise-returned-context to do work.

My usage shows `environment()` should be just one,
instead of multiple as I originially thought.
The detail config of the environment should be leave to the `spec`.