### PR TITLE
fix: improve class detection.

### DIFF
--- a/src/class/isClass.spec.ts
+++ b/src/class/isClass.spec.ts
@@ -1,5 +1,6 @@
 import t from 'assert'
 
+// import isClass from 'isclass'
 import { isClass } from './isClass'
 
 
@@ -20,12 +21,10 @@ test('false for method in object', () => {
   const obj = {
     f() { return }
   }
-
   t(!isClass(obj.f))
 })
 
 test('true for class with at lease one method', () => {
   class F { f() { return } }
-
   t(isClass(F))
 })

--- a/src/class/isClass.ts
+++ b/src/class/isClass.ts
@@ -2,5 +2,8 @@
 export function isClass(subject) {
   // made a reasonable tradeoff assuming there will be at least one method in the class.
   // after all, there will be nothing to spy/stub if there is no method.
-  return typeof subject === 'function' && subject.prototype && Object.keys(subject.prototype).length !== 0;
+  return typeof subject === 'function' &&
+    subject.prototype &&
+    // the prototype will always at least having 'constructor' in it, even for functions
+    Object.getOwnPropertyNames(subject.prototype).length > 1
 }


### PR DESCRIPTION
The previous detection doesn't work on ES6 class directly in NodeJS.

`Object.keys(subject)` returns empty array.