### PR TITLE
feat: distributing es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,18 +2,16 @@
   "name": "komondor",
   "description": "Your friendly guard dog for writing tests across boundaries",
   "version": "0.0.0-development",
-  "main": "dist-es5/index.js",
-  "module": "dist-esnext/index.js",
-  "typings": "dist-es5/index.d.ts",
+  "main": "dist-es2015/index.js",
+  "typings": "dist-es2015/index.d.ts",
   "files": [
-    "dist-es5",
-    "dist-esnext"
+    "dist-es2015"
   ],
   "scripts": {
-    "build": "npm run clean && npm run build-es5 && npm run build-esnext",
+    "build": "npm run clean && npm run build-es2015",
     "build-es5": "tsc -p tsconfig.es5.json",
-    "build-esnext": "tsc -p tsconfig.esnext.json",
-    "clean": "rimraf dist dist-es5 && rimraf dist-esnext",
+    "build-es2015": "tsc -p tsconfig.es2015.json",
+    "clean": "rimraf dist dist-es5 && rimraf dist-es2015",
     "codecov": "codecov",
     "coverage": "jest --coverage",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",

--- a/tsconfig.es2015.json
+++ b/tsconfig.es2015.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist-esnext",
-    "target": "esnext"
+    "outDir": "dist-es2015",
+    "target": "es2015"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.es5.json",
+  "extends": "./tsconfig.es2015.json",
   "atom": {
     "rewriteTsconfig": false
   },


### PR DESCRIPTION
Transpiling to es2015 is needed to support JS class, due to:
https://github.com/Microsoft/TypeScript/issues/23553