### PR TITLE
fix: set fixture package.json versions to 0.0.0 (pnpm 11 rejects null)

### DIFF
--- a/packages/nodejs/fixtures/has-plugins/package.json
+++ b/packages/nodejs/fixtures/has-plugins/package.json
@@ -7,5 +7,5 @@
 		"@mocktomata/plugin-fixture-no-activate": "workspace:^",
 		"@mocktomata/plugin-fixture-activate-not-fn": "workspace:^"
 	},
-	"version": null
+	"version": "0.0.0"
 }

--- a/packages/nodejs/fixtures/plugin-cjs/package.json
+++ b/packages/nodejs/fixtures/plugin-cjs/package.json
@@ -12,5 +12,5 @@
       "plugin-a"
     ]
   },
-  "version": null
+  "version": "0.0.0"
 }

--- a/packages/nodejs/fixtures/plugin-esm/package.json
+++ b/packages/nodejs/fixtures/plugin-esm/package.json
@@ -16,5 +16,5 @@
 			"plugin-a"
 		]
 	},
-	"version": null
+	"version": "0.0.0"
 }


### PR DESCRIPTION
pnpm 11 validates `package.json` more strictly and rejects `"version": null`. This fix sets fixture package versions to `"0.0.0"` which unblocks all open PRs (including the turbo v2 security update #609).

Affected files:
- `packages/nodejs/fixtures/has-plugins/package.json`
- `packages/nodejs/fixtures/plugin-cjs/package.json`  
- `packages/nodejs/fixtures/plugin-esm/package.json`